### PR TITLE
Fix log base in bits representation calculation

### DIFF
--- a/content/number-rep/index.md
+++ b/content/number-rep/index.md
@@ -139,7 +139,7 @@ Put another way, you can represent $k$ things in at minimum $N$ bits, where $N =
 ^^^
 There are 26 lowercase letters in the English language:  `a`, `b`, ..., `z`.
 
-$\log_2 (26) = \log_{10}(26)/\log_2(2) \approx 4.7$
+$\log_2 (26) = \log_{10}(26)/\log_10(2) \approx 4.7$
 
 We therefore need at least **5 bits**.
 


### PR DESCRIPTION
Log base 10 should be used instead of 2. $\log_{10}\left(26\right)/\log_{2}\left(2\right)$ should become $\log_{10}\left(26\right)/\log_{10}\left(2\right)$.