### PR TITLE
fix(lec06): left and right shift descriptions

### DIFF
--- a/content/c-odds-and-ends/index.md
+++ b/content/c-odds-and-ends/index.md
@@ -162,13 +162,13 @@ Suppose you have the 8-bit bit patterns (where we put spaces between nibbles for
 * `x`, with bit pattern `0001 0001`
 * `y`, with bit pattern `1111 0001`
 
-**Left shift** `x << n` shifts the bits of `x` left by `n` bytes, filling the lower bits coming in from the right with `0`'s. Mathematically, this is equivalent to multiplying `x` by $2^{\texttt{n}}$. For example, `x << 3` gives the bit pattern `0000 1000`, where the leftmost `1` gets "shifted out."
+**Left shift** `x << n` shifts the bits of `x` left by `n` bits, filling the `n` lower bits ("coming in from the right") with `0`'s. Mathematically, this is equivalent to multiplying `x` by $2^{\texttt{n}}$. For example, `x << 3` gives the bit pattern `0000 1000`, where the leftmost `1` gets "shifted out."
 
-**Right shift**, `x >> n` shifts the bits of `x` right by `n` bytes. Mathematically, this is equivalent to taking the floor of a division by $2^{\texttt{n}}4 We will still need to fill in the top bits coming in from the right somehow, but the precise operation in C depends on `x`'s type.
+**Right shift**, `x >> n` shifts the bits of `x` right by `n` bits. Mathematically, this is equivalent to taking the floor of a division by $2^{\texttt{n}}4 We will still need to fill in the top bits coming in from the right somehow, but the precise operation in C depends on `x`'s type.
 
-* **Logical right shift** "zero-extends" and fills the top bits with `0`. If `x` is an unsigned 8-bit integer, then `x >> 2` gives the bit pattern `0000 0100`, where the rightmost `1` gets shifted out. This is equivalent to `(unsigned char) 17 >> 2` yielding `4`.
+* **Logical right shift** "zero-extends" and fills the upper bits with `0`. If `x` is an unsigned 8-bit integer, then `x >> 2` gives the bit pattern `0000 0100`, where the rightmost `1` gets shifted out. This is equivalent to `(unsigned char) 17 >> 2` yielding `4`.
 
-* **Arithmetic right shift** "sign-extends" and fills the top bits with the sign bit of `x`. Arithmetic right shift therefore preserves the sign bit of the result when using signed operands.
+* **Arithmetic right shift** "sign-extends" and fills the upper bits with the sign bit of `x`. Arithmetic right shift therefore preserves the sign bit of the result when using signed operands.
 
 :::{note} Example
 

--- a/content/misc/iec-prefixes.md
+++ b/content/misc/iec-prefixes.md
@@ -1,5 +1,5 @@
 ---
-title: "Binary and Base-10 Prefixes"
+title: "IEC and Base-10 Prefixes"
 ---
 
 ## Learning Outcomes
@@ -58,7 +58,7 @@ What is 4 KB?
 4,000 bytes. 4 KB = $ 4 \times 10^3 $ B
 :::
 
-## Binary prefixes
+## IEC (Binary) prefixes
 
 The IEC (International Electrotechnical Commission) defined binary prefixes like "kibi", "mebi", etc., to describe large binary numbers. @tab-binary-prefixes describes the binary prefixes commonly used in this class.
 

--- a/myst.yml
+++ b/myst.yml
@@ -69,7 +69,7 @@ project:
         - file: content/c-generics/exercises.md
     - title: "Miscellaneous"
       children:
-        - file: content/misc/unit-prefixes.md
+        - file: content/misc/iec-prefixes.md
 site:
   template: book-theme
   options:


### PR DESCRIPTION
A left shift fills in bytes with `0`s from the right, not the left. 

Additionally, I believe that specifying that `n` is the number of bytes the shift operators are shifting `x` and `y` by would be helpful. As a result, I changed the wording to say, "shifts the bits of `x/y` left by `n` bytes".