### PR TITLE
feat(lec08): improved summary with cross-references

### DIFF
--- a/content/floating-point/summary.md
+++ b/content/floating-point/summary.md
@@ -7,11 +7,13 @@ title: "Summary"
 
 The IEEE 754 standard defines a binary representation for floating point values using three fields.
 
-* The *sign* determines the sign of the number ($0 $ for positive, $1 $ for negative).
-* The *exponent* is in biased notation. For instance, the bias is $−127$, which comes from $-(2^{(8−1)} −1)$ for single-precision floating point numbers. For double-precision floating point numbers, the bias is $−1023$. An exponent of `00000000` represents a *denormalized number* and an exponent of `11111111` represents either *NaN*, if there is a non-zero mantissa, or *infinity*, if there is a zero mantissa.
-* The *significand* is used to store a **fraction** instead of an integer and refers to the bits to the right of the leading "`1`" when normalized. For example, if a mantissa is `1.010011`, its significand is `010011`.
+:::{figure} #fig-float
+Single-Precision (32-bit) Floating Point Representation (reprint of @fig-float from [this section](#sec-fp)). The leftmost bit is the most significant bit; the rightmost bit is the least significant bit.
+:::
 
-@fig-float shows the bit breakdown for the single-precision (32-bit) representation. The leftmost bit is the MSB, and the rightmost bit is the LSB.
+* The *sign* determines the sign of the number ($0 $ for positive, $1 $ for negative).
+* The *exponent* is in biased notation. For single-precision floating point numbers, the bias is $−127$, which comes from $-(2^{(8−1)} −1)$. For double-precision floating point numbers, the bias is $−1023$. An exponent of `00000000` represents a *denormalized number* and an exponent of `11111111` represents either *NaN*, if there is a non-zero mantissa, or *infinity*, if there is a zero mantissa.
+* The *significand* is used to store a **fraction** instead of an integer and refers to the bits to the right of the leading "`1`" when normalized. For example, if a mantissa is `1.010011`, its significand is `010011`.
 
 
 * For [normalized floats](#sec-normalized):
@@ -22,7 +24,11 @@ $$\text{Value} = (−1)^{\text{Sign}} × 2^{\text{Exp}+\text{Bias}} × 1.\text{S
 
 $$\text{Value} = (−1)^{\text{Sign}} × 2^{\text{Exp}+\text{Bias}+1} × 0.\text{Significand}_2$$
 
-@tab-float-exp-fields shows that the IEEE 754 exponent field has values from $0$ to $255$. When translating between binary and decimal floating point values, we must remember that there is a bias for the exponent.
+When translating between binary and decimal floating point values, we must remember that there is a bias for the exponent.
+
+:::{figure} #tab-float-exp-fields
+The IEEE 754 single-precision exponent field has values from $0$ to $255 (reprint of @tab-float-exp-fields from [this section](#sec-special-floats)).
+:::
 
 ## Textbook Readings
 


### PR DESCRIPTION
Improved directive + cross-reference notation for summary, e.g.,

```
:::{figure} #tab-float-exp-fields
The IEEE 754 single-precision exponent field has values from $0$ to $255 (reprint of @tab-float-exp-fields from [this section](#sec-special-floats)).
:::
```