### PR TITLE
fix(endianness): correct markdown syntax for address space reference and MSB

### DIFF
--- a/content/c-odds-and-ends/endianness.md
+++ b/content/c-odds-and-ends/endianness.md
@@ -162,7 +162,7 @@ When data occupies multiple contiguous bytes in memory, the computer must determ
 This property is called **endianness**.[^gulliver] For a given word:
 
 * **Little endian** machines store the _least_significant byte_ first, at the lowest address of the word.
-* **Big endian** machines store the _most_ significant byte_ first, at the lowest address of the word.
+* **Big endian** machines store the _most_significant byte_ first, at the lowest address of the word.
 
 The choice of endianness is one of convention[^endianness]. Nearly all modern computer architectures are little endian.
 


### PR DESCRIPTION
The current Markdown syntax (@sec-address-space) incorrectly attempts to redirect to a non-existent external URL (https://notes.cs61c.org/@sec-address-space) instead of an internal anchor. This PR fixes that problem, ensuring the link correctly scrolls to the "Address Space" section on the same page