### PR TITLE
feat(number-rep): phrasing

### DIFF
--- a/content/number-rep/binary-decimal-hex.md
+++ b/content/number-rep/binary-decimal-hex.md
@@ -345,10 +345,8 @@ We don't expect you to understand this code at this time. We will discuss C synt
 Remember that there is only ever one number; this value that can be represented in multiple ways. The below are all representations of the same number, thirty-two:
 
 * $32_{10}$, or simply $32$. We recommend you write $32_{ten}$ if you're writing by hand.
-* `0x20`, or the hexadecimal numeral `20`
-* `0b10000`, or the binary numeral `10000`
-* $20_{16}$. We recommend $20_{hex}$ if you're writing by hand.
-* $10000_{2}$. We recommend $10000_{two}$ if you're writing by hand.
+* `0x20`, or the hexadecimal numeral $20$. Since the latter is already our default base-10 representation, we recommend prefixing with `0x` or (if writing by hand) using subscripts, e.g., $20_{16}$ or $20_{hex}$.
+* `0b100000`, or the binary numeral $100000$. Again, we recommend prefixing or (if writing by hand) using subscripts, e.g., $100000_{2}$ or $100000_{two}$.
 
 Different representations serve different purposes:
 

--- a/content/number-rep/integer-representations.md
+++ b/content/number-rep/integer-representations.md
@@ -46,9 +46,9 @@ This representation is supported in C (discussed more later). Built-in types lik
 
 :::{caution} How many bits do we need for a system that supports $10 + 7$?
 
-* 10 in binary is `1010`. 4 bits.
-* 7 in binary is `0111`. 4 bits.
-* 17 in binary is `10001`. **5 bits**.
+* 10 as a 4-bit unsigned integer is `1010`.
+* 7 as a 4-bit unsigned integer is `0111`.
+* 17 requires a **5-bit** unsigned integer container: `10001`.
 
 If we used a 4-bit unsigned integer representation, we wouldn't have enough room to represent the number 17. Instead, our "binary odometer" would truncate the result, cropping off the leftmost `1` and storing `0001`. So binary addition with 4-bit unsigned integers would imply that $10 + 7 = 1$...?!
 

--- a/content/number-rep/integer-representations.md
+++ b/content/number-rep/integer-representations.md
@@ -46,9 +46,9 @@ This representation is supported in C (discussed more later). Built-in types lik
 
 :::{caution} How many bits do we need for a system that supports $10 + 7$?
 
-* 10 as a 4-bit unsigned integer is `1010`.
-* 7 as a 4-bit unsigned integer is `0111`.
-* 17 requires a **5-bit** unsigned integer container: `10001`.
+* 10 in binary is $1010_2$, which can be stored as a 4-bit unsigned integer: `1010`
+* 7 in binary is $111_2$, which can also be stored as a 4-bit unsigned integer with some zero-padding: `0111`.
+* 17 in binary is $10001_2$, which at minimum requires **5 bits** of storage.
 
 If we used a 4-bit unsigned integer representation, we wouldn't have enough room to represent the number 17. Instead, our "binary odometer" would truncate the result, cropping off the leftmost `1` and storing `0001`. So binary addition with 4-bit unsigned integers would imply that $10 + 7 = 1$...?!
 


### PR DESCRIPTION
Fix binary representation phrasing in 10 + 7 example

7 in binary is 111, including the leading 0 is a choice to make it a 4 bit representation. this distinction might be good to make clear. 
